### PR TITLE
Update Retrush to 2.0 release

### DIFF
--- a/data.json
+++ b/data.json
@@ -106,20 +106,20 @@
       "type": "mappack",
       "name": "Retrush",
       "description": "Blast through the\npast, and blaze a\nfearless trail!",
-      "version": "1.0.1",
+      "version": "2.0",
       "author": "Skysometric",
       "download": {
         "url": "https://www.dropbox.com/s/did8ruxscgdx8oj/Retrush.zip?dl=1",
         "filename": "Retrush.zip"
       },
       "released": "2023-04-27",
-      "updated": "2023-04-27",
+      "updated": "2026-02-09",
       "game_version": {
         "derivative": [
           "AE"
         ],
         "ranges": [
-          ">=13.1"
+          ">=13.2"
         ]
       },
       "icon": "https://i.imgur.com/r7LfCo6.png",


### PR DESCRIPTION
Yes, the URL is exactly the same; I explicitly set it up as an update to the existing zip file. This PR just updates the rest of the metadata.